### PR TITLE
Adopt session-backed workflow state

### DIFF
--- a/src/agent_pipeline/agents/runconfig.py
+++ b/src/agent_pipeline/agents/runconfig.py
@@ -2,10 +2,25 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from typing import Any
+
 from agents.run import RunConfig
 
 from ..config import PipelineConfig
 from ..logging import AgentCallContext
+
+
+def _merge_session_history(
+    history: Sequence[dict[str, Any]],
+    new_items: Sequence[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Merge session ``history`` with ``new_items`` preserving order."""
+
+    merged: list[dict[str, Any]] = []
+    merged.extend(history)
+    merged.extend(new_items)
+    return merged
 
 
 def build_run_config(config: PipelineConfig, context: AgentCallContext) -> RunConfig:
@@ -17,4 +32,5 @@ def build_run_config(config: PipelineConfig, context: AgentCallContext) -> RunCo
         workflow_name=config.workflow_name,
         trace_id=context.trace_id,
         trace_metadata=trace_metadata,
+        session_input_callback=_merge_session_history,
     )

--- a/src/agent_pipeline/agents/runner.py
+++ b/src/agent_pipeline/agents/runner.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 import trio
-from agents import Agent
+from agents import Agent, Session
 from agents.run import RunConfig
 
 from ..bridge.asyncio import run_agent as run_agent_asyncio
@@ -32,6 +32,7 @@ async def call_agent(
     limiter_pool: LimiterPool,
     timeout: float | None = None,
     run_max_turns: int | None = None,
+    session: Session | None = None,
 ) -> Any:
     """Call ``agent`` with concurrency limiting and logging."""
 
@@ -47,6 +48,7 @@ async def call_agent(
                     "context": context,
                     "hooks": hooks,
                     "run_config": run_config,
+                    "session": session,
                 }
                 if run_max_turns is not None:
                     kwargs["max_turns"] = run_max_turns


### PR DESCRIPTION
## Summary
- use an SQLiteSession per document to let the workflow maintain conversation history automatically
- update WorkflowRunner to drive each stage with session-backed prompts, rewinding review state via pop_item on rejection
- expand the workflow runner tests to exercise session persistence and rework behaviour

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce9ad341f48326b7a2828683248bcf